### PR TITLE
chore: ignore mac metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS-specific files
+.DS_Store
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Summary
- avoid committing macOS metadata by ignoring `.DS_Store`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc185a948321a37af30fc1c0c697